### PR TITLE
Add FastAPI URL Shortener with CRUD Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,121 @@
-# Amina-innovaxel-Bibi
+# FastAPI URL Shortener
+
+This is a simple URL shortener API built using FastAPI and SQLite. It allows users to shorten URLs, retrieve original URLs, track access statistics, update existing URLs, and delete short URLs.
+
+## Features
+- Shorten a given URL
+- Retrieve the original URL using the short code
+- Track the number of times a short URL has been accessed
+- Update an existing short URL
+- Delete a short URL
+
+## Installation
+
+### Prerequisites
+- Python 3.8+
+- Git
+- SQLite (comes pre-installed with Python)
+
+### Steps
+1. **Clone the repository:**
+   ```sh
+   git clone https://github.com/Ami9a-Bibi/Amina-innovaxel-Bibi.git
+   cd Amina-innovaxel-Bibi
+   ```
+2. **Switch to the `dev` branch:**
+   ```sh
+   git checkout dev
+   ```
+3. **Create a virtual environment (optional but recommended):**
+   ```sh
+   python -m venv venv
+   source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
+   ```
+4. **Install dependencies:**
+   ```sh
+   pip install -r requirements.txt
+   ```
+
+## Running the API
+Start the FastAPI server using Uvicorn:
+```sh
+uvicorn main:app --reload
+```
+The API will be available at `http://127.0.0.1:8000`.
+
+## API Endpoints
+
+### 1. Shorten URL
+**POST** `/shorten`
+#### Request Body:
+```json
+{
+  "url": "https://example.com"
+}
+```
+#### Response:
+```json
+{
+  "id": 1,
+  "url": "https://example.com",
+  "shortCode": "abc123",
+  "createdAt": "2025-03-18T12:00:00",
+  "updatedAt": "2025-03-18T12:00:00"
+}
+```
+
+### 2. Retrieve Original URL
+**GET** `/{short_code}`
+#### Response:
+```json
+{
+  "id": 1,
+  "url": "https://example.com",
+  "shortCode": "abc123",
+  "createdAt": "2025-03-18T12:00:00",
+  "updatedAt": "2025-03-18T12:00:00"
+}
+```
+
+### 3. Get URL Statistics
+**GET** `/stats/{short_code}`
+#### Response:
+```json
+{
+  "id": 1,
+  "url": "https://example.com",
+  "shortCode": "abc123",
+  "createdAt": "2025-03-18T12:00:00",
+  "updatedAt": "2025-03-18T12:00:00",
+  "accessCount": 5
+}
+```
+
+### 4. Update Short URL
+**PUT** `/shorten/{short_code}`
+#### Request Body:
+```json
+{
+  "url": "https://newexample.com"
+}
+```
+#### Response:
+```json
+{
+  "id": 1,
+  "url": "https://newexample.com",
+  "shortCode": "abc123",
+  "createdAt": "2025-03-18T12:00:00",
+  "updatedAt": "2025-03-18T12:10:00"
+}
+```
+
+### 5. Delete Short URL
+**DELETE** `/shorten/{short_code}`
+#### Response:
+```json
+{
+  "message": "Short URL deleted successfully"
+}
+```
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,3 @@
+from fastapi import FastAPI
+
+app = FastAPI()

--- a/main.py
+++ b/main.py
@@ -115,3 +115,16 @@ def update_short_url(short_code: str, url: str = Body(..., embed=True)):
         "createdAt": url_entry.createdAt,
         "updatedAt": url_entry.updatedAt,
     }
+
+@app.delete("/shorten/{short_code}")
+def delete_short_url(short_code: str):
+    db = SessionLocal()
+    url_entry = db.query(URL).filter(URL.shortCode == short_code).first()
+    
+    if not url_entry:
+        db.close()
+        raise HTTPException(status_code=404, detail="Not Found")
+    
+    db.delete(url_entry)
+    db.commit()
+    db.close()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,11 @@
 from fastapi import FastAPI
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, func
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 app = FastAPI()
+
+# Database setup
+DATABASE_URL = "sqlite:///./shortener.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/main.py
+++ b/main.py
@@ -93,3 +93,25 @@ def get_url_stats(short_code: str):
         "updatedAt": url_entry.updatedAt,
         "accessCount": url_entry.visit_count,
     }
+
+@app.put("/shorten/{short_code}")
+def update_short_url(short_code: str, url: str = Body(..., embed=True)):
+    db = SessionLocal()
+    url_entry = db.query(URL).filter(URL.shortCode == short_code).first()
+    
+    if not url_entry:
+        db.close()
+        raise HTTPException(status_code=404, detail="Not Found")
+    
+    url_entry.url = url
+    db.commit()
+    db.refresh(url_entry)
+    db.close()
+    
+    return {
+        "id": url_entry.id,
+        "url": url_entry.url,
+        "shortCode": url_entry.shortCode,
+        "createdAt": url_entry.createdAt,
+        "updatedAt": url_entry.updatedAt,
+    }

--- a/main.py
+++ b/main.py
@@ -36,7 +36,6 @@ def shorten_url(request: URLRequest):
     db = SessionLocal()
     short_code = generate_short_code()
     
-    # Commit 5: Generate unique short codes
     while db.query(URL).filter(URL.shortCode == short_code).first():
         short_code = generate_short_code()
     
@@ -52,4 +51,26 @@ def shorten_url(request: URLRequest):
         "shortCode": new_url.shortCode,
         "createdAt": new_url.createdAt,
         "updatedAt": new_url.updatedAt,
+    }
+
+@app.get("/{short_code}")
+def get_original_url(short_code: str):
+    db = SessionLocal()
+    url_entry = db.query(URL).filter(URL.shortCode == short_code).first()
+    
+    if not url_entry:
+        db.close()
+        raise HTTPException(status_code=404, detail="Not Found")
+    
+    url_entry.visit_count += 1
+    db.commit()
+    db.refresh(url_entry)
+    db.close()
+    
+    return {
+        "id": url_entry.id,
+        "url": url_entry.url,
+        "shortCode": url_entry.shortCode,
+        "createdAt": url_entry.createdAt,
+        "updatedAt": url_entry.updatedAt,
     }

--- a/main.py
+++ b/main.py
@@ -74,3 +74,22 @@ def get_original_url(short_code: str):
         "createdAt": url_entry.createdAt,
         "updatedAt": url_entry.updatedAt,
     }
+
+
+@app.get("/stats/{short_code}")
+def get_url_stats(short_code: str):
+    db = SessionLocal()
+    url_entry = db.query(URL).filter(URL.shortCode == short_code).first()
+    db.close()
+    
+    if not url_entry:
+        raise HTTPException(status_code=404, detail="Not Found")
+    
+    return {
+        "id": url_entry.id,
+        "url": url_entry.url,
+        "shortCode": url_entry.shortCode,
+        "createdAt": url_entry.createdAt,
+        "updatedAt": url_entry.updatedAt,
+        "accessCount": url_entry.visit_count,
+    }

--- a/main.py
+++ b/main.py
@@ -9,3 +9,15 @@ DATABASE_URL = "sqlite:///./shortener.db"
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+class URL(Base):
+    __tablename__ = "urls"
+    
+    id = Column(Integer, primary_key=True, index=True)
+    url = Column(String, nullable=False)
+    shortCode = Column(String, unique=True, index=True, nullable=False)
+    createdAt = Column(DateTime, default=func.now())
+    updatedAt = Column(DateTime, default=func.now(), onupdate=func.now())
+    visit_count = Column(Integer, default=0)
+
+Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
- Implemented a FastAPI-based URL shortener.
- Integrated SQLite database using SQLAlchemy.
- Added endpoints for:
    
    1.     Shortening a URL (POST /shorten)
    2.     Retrieving original URL (GET /{short_code})
    3.     Fetching URL statistics (GET /stats/{short_code})
    4.     Updating an existing short URL (PUT /shorten/{short_code})
    5.     Deleting a short URL (DELETE /shorten/{short_code})

- Improved error handling.
- Updated README with setup instructions and API documentation.